### PR TITLE
Add quality_report output to module

### DIFF
--- a/modules/local/build_resources.wdl
+++ b/modules/local/build_resources.wdl
@@ -49,6 +49,8 @@ task build_targeted_reference {
 task build_resmarker_info {
   input {
     File amplicon_info
+    #TODO: This file is https://github.com/EPPIcenter/mad4hatter/blob/update_dockerfile/panel_information/principal_resistance_marker_info_table.tsv
+    #TODO: It should be added to updated docker file and can be removed from inputs
     File principal_resmarkers
     File resmarker_info_output_path
     String docker_name = "your_docker_image"

--- a/modules/local/build_resources.wdl
+++ b/modules/local/build_resources.wdl
@@ -50,8 +50,8 @@ task build_resmarker_info {
   input {
     File amplicon_info
     #TODO: This file is https://github.com/EPPIcenter/mad4hatter/blob/update_dockerfile/panel_information/principal_resistance_marker_info_table.tsv
-    #TODO: It should be added to updated docker file and can be removed from inputs
-    File principal_resmarkers
+    #TODO: It should be added to updated docker file and we should ensure path is correct
+    File principal_resmarkers = "principal_resistance_marker_info_table.tsv"
     File resmarker_info_output_path
     String docker_name = "your_docker_image"
   }

--- a/modules/local/quality_report.wdl
+++ b/modules/local/quality_report.wdl
@@ -30,6 +30,7 @@ task quality_report {
   output {
     File sample_coverage_out = "sample_coverage.txt"
     File amplicon_coverage_out = "amplicon_coverage.txt"
+    Directory quality_report = "quality_report"
   }
 
   runtime {


### PR DESCRIPTION
Adding output from - https://github.com/EPPIcenter/mad4hatter/blob/update_dockerfile/modules/local/quality_report.nf#L19. It says file there, but the output is actually a whole directory full of files.
```
$ ls ./work/bc/87dc9022eff5b491a056194fd7431c/quality_report
amplicon_stats.txt	length_vs_reads.pdf	QCplots.html		QCplots.Rmd		reads_histograms.pdf	swarm_plots.pdf
```